### PR TITLE
Fix https redirect behind Render proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:${PORT:-8000}/health || exit 1
 
 # Run the application with production settings
-CMD uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000} --workers 1
+CMD uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000} --workers 1 --proxy-headers --forwarded-allow-ips="*"

--- a/app/api/v1/endpoints/coffees.py
+++ b/app/api/v1/endpoints/coffees.py
@@ -58,7 +58,7 @@ def _build_coffee_response(coffee: dict) -> CoffeeResponse:
     )
 
 
-@router.post("/", response_model=CoffeeResponse, status_code=201)
+@router.post("", response_model=CoffeeResponse, status_code=201)
 async def create_coffee(
     coffee_data: CoffeeCreate,
     session: AsyncSession = Depends(get_graph_db),
@@ -102,7 +102,7 @@ async def create_coffee(
         raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
-@router.get("/", response_model=CoffeeListResponse)
+@router.get("", response_model=CoffeeListResponse)
 async def list_coffees(
     skip: int = Query(0, ge=0, description="Number of coffees to skip"),
     limit: int = Query(20, ge=1, le=100, description="Number of coffees to return"),

--- a/app/api/v1/endpoints/flavors.py
+++ b/app/api/v1/endpoints/flavors.py
@@ -15,7 +15,7 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
-@router.post("/", response_model=FlavorResponse, status_code=201)
+@router.post("", response_model=FlavorResponse, status_code=201)
 async def create_flavor(
     flavor_data: FlavorCreate,
     session: AsyncSession = Depends(get_graph_db),
@@ -51,7 +51,7 @@ async def create_flavor(
         raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
-@router.get("/", response_model=FlavorListResponse)
+@router.get("", response_model=FlavorListResponse)
 async def list_flavors(
     skip: int = Query(0, ge=0, description="Number of flavors to skip"),
     limit: int = Query(50, ge=1, le=100, description="Number of flavors to return"),

--- a/app/api/v1/endpoints/me.py
+++ b/app/api/v1/endpoints/me.py
@@ -22,7 +22,7 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
-@router.get("/", response_model=UserProfile)
+@router.get("", response_model=UserProfile)
 async def get_current_user_profile(
     session: AsyncSession = Depends(get_graph_db),
     user_id: str = Depends(ensure_user_exists),
@@ -48,7 +48,7 @@ async def get_current_user_profile(
         raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
-@router.patch("/", response_model=UserProfile)
+@router.patch("", response_model=UserProfile)
 async def update_current_user_profile(
     profile_data: UserProfileUpdate,
     session: AsyncSession = Depends(get_graph_db),

--- a/app/api/v1/endpoints/roasters.py
+++ b/app/api/v1/endpoints/roasters.py
@@ -20,7 +20,7 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
-@router.post("/", response_model=RoasterResponse, status_code=201)
+@router.post("", response_model=RoasterResponse, status_code=201)
 async def create_roaster(
     roaster_data: RoasterCreate,
     session: AsyncSession = Depends(get_graph_db),
@@ -66,7 +66,7 @@ async def create_roaster(
         raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
-@router.get("/", response_model=RoasterListResponse)
+@router.get("", response_model=RoasterListResponse)
 async def list_roasters(
     skip: int = Query(0, ge=0, description="Number of roasters to skip"),
     limit: int = Query(20, ge=1, le=100, description="Number of roasters to return"),

--- a/app/api/v1/endpoints/tastings.py
+++ b/app/api/v1/endpoints/tastings.py
@@ -101,7 +101,7 @@ def _build_tasting_response(tasting: dict) -> TastingResponse:
     )
 
 
-@router.post("/", response_model=TastingResponse, status_code=201)
+@router.post("", response_model=TastingResponse, status_code=201)
 async def create_tasting(
     tasting_data: TastingCreate,
     session: AsyncSession = Depends(get_graph_db),
@@ -151,7 +151,7 @@ async def create_tasting(
         raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
-@router.get("/", response_model=TastingListResponse)
+@router.get("", response_model=TastingListResponse)
 async def list_tastings(
     skip: int = Query(0, ge=0, description="Number of tastings to skip"),
     limit: int = Query(20, ge=1, le=100, description="Number of tastings to return"),


### PR DESCRIPTION
## Summary
- Enable uvicorn `--proxy-headers` so `X-Forwarded-Proto: https` from Render's TLS-terminating proxy is honored. Without it, FastAPI's trailing-slash 307 redirects rebuild the `Location` as `http://`, which browsers block as mixed content from an HTTPS page.
- Drop trailing slash from collection routes (`/me`, `/coffees`, `/tastings`, `/roasters`, `/flavors`) so no slash redirect fires in the first place. Defense in depth.

## Why
Frontend requests to `https://coffee-tasting-api.onrender.com/api/v1/me` were returning 307 with `Location: http://coffee-tasting-api.onrender.com/api/v1/me/` and the browser wasn't following the redirect. Sub-path routes like `/me/flavor-profile` were fine because they matched directly without a redirect.

## Test plan
- [ ] After deploy, `curl -I https://coffee-tasting-api.onrender.com/api/v1/me` should return 401 (auth required) or 200, not 307.
- [ ] If a 307 does occur on any path, confirm the `Location` header starts with `https://`, not `http://`.
- [ ] Verify the frontend can reach `/api/v1/me`, `/api/v1/tastings`, `/api/v1/coffees` without the Network tab stalling on a 307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)